### PR TITLE
Correction de bug à la modification d'utilisateur étudiant et proffesseur

### DIFF
--- a/controller/MainController.php
+++ b/controller/MainController.php
@@ -94,9 +94,7 @@
         public static function updateUserInformation(): void {
             try {
 
-                $userToUpdate = User::getByLogin($_SESSION['User']->getLogin());
-                $userToUpdate->changePassword(...FormValidator::validateUpdateUserInformation());
-                $_SESSION['User']  = $userToUpdate;
+                $_SESSION['User']->changePassword(...FormValidator::validateUpdateUserInformation());
                 $query = ['action' => 'settings', 'sucess' => 'Utilisateur modifié'];
                 header(INDEX_LOCATION . '?' . http_build_query($query));
             } catch (DataBaseException | UserException $e) {

--- a/model/LOPStudents/Student.php
+++ b/model/LOPStudents/Student.php
@@ -51,7 +51,22 @@
             $id = 220000 + ($res['max(id)+1'] != null ? $res['max(id)+1'] : 1);
             return 'ENSA' . (string)$id;
         }
+        public function changePassword(string $newPassword, string $newLogin): void {
+            try {
 
+                $con = FACTORY->get_connexion();
+                $sql = 'update etudiants set 
+                 login=?  where login=?';
+                $statement = $con->prepare($sql);
+                $statement->execute([$newLogin, $this->login]);
+                Parent::changePassword($newPassword, $newLogin);
+            } catch (PDOException $e) {
+                if ($e->getCode() == 23000) {
+                    throw new DataBaseException("Ce nom d'utilisateur existe déja dans la base de données");
+                }
+                throw new DataBaseException($e->getMessage());
+            }
+        }
         /**
          * Renvoie une partie de la liste de tous les étudiants en jointure avec leur utilisateur correspondant
          * @param int $first Premier element de la liste

--- a/model/LOPStudents/Teacher.php
+++ b/model/LOPStudents/Teacher.php
@@ -70,6 +70,23 @@
             return self::changeToTeacher($res);
         }
 
+        public function changePassword(string $newPassword, string $newLogin): void {
+            try {
+
+                $con = FACTORY->get_connexion();
+                $sql = 'update professeur set 
+                 login=?  where login=?';
+                $statement = $con->prepare($sql);
+                $statement->execute([$newLogin, $this->login]);
+                Parent::changePassword($newPassword, $newLogin);
+            } catch (PDOException $e) {
+                if ($e->getCode() == 23000) {
+                    throw new DataBaseException("Ce nom d'utilisateur existe déja dans la base de données");
+                }
+                throw new DataBaseException('Une erreur est survenue de notre part');
+            }
+        }
+
         /**
          * Permet d'avoir le nombre actuel de profs
          * @return int

--- a/model/LOPStudents/Trait/Filter/TeacherFilter.php
+++ b/model/LOPStudents/Trait/Filter/TeacherFilter.php
@@ -16,6 +16,7 @@
             $con = FACTORY->get_connexion();
             $sql = "SELECT * FROM professeur NATURAL JOIN users WHERE login='" . $login . "'";
             $res = $con->query($sql)->fetch(PDO::FETCH_ASSOC);
+            print(gettype($res));
             return new Teacher(...$res);
         }
 

--- a/model/LOPStudents/User.php
+++ b/model/LOPStudents/User.php
@@ -71,6 +71,8 @@
                  password=?, login=?  where login=?';
                 $statement = $con->prepare($sql);
                 $statement->execute([$newPassword, $newLogin, $this->login]);
+                $this->login = $newLogin;
+                $this->password = $newPassword;
             } catch (PDOException $e) {
                 if ($e->getCode() == 23000) {
                     throw new DataBaseException("Ce nom d'utilisateur existe déja dans la base de données");


### PR DESCRIPTION
Avant quand on modifiait un proffesseur ou un étudiant cela ne modifiais pas le champ login dans la classe fille correspondante mais juste dans la classe mère user